### PR TITLE
Add ability to specify extra  for the provider deployment

### DIFF
--- a/chart/loadbalancer-provider-haproxy/templates/deployment.yaml
+++ b/chart/loadbalancer-provider-haproxy/templates/deployment.yaml
@@ -50,7 +50,10 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "common.names.fullname" . }}-config
-          {{- if .Values.provider.securityContext }}
+          {{- if .Values.provider.extraEnvFrom }}
+            {{- toYaml .Values.provider.extraEnvFrom | nindent 12 }}
+         {{- end }} 
+         {{- if .Values.provider.securityContext }}
           securityContext:
             {{- toYaml .Values.provider.securityContext | nindent 12 }}
           {{- end }}

--- a/chart/loadbalancer-provider-haproxy/values.yaml
+++ b/chart/loadbalancer-provider-haproxy/values.yaml
@@ -26,6 +26,7 @@ provider:
   replicas: 1
   extraLabels: []
   extraAnnotations: []
+  extraEnvFrom: {}
   extraEnvVars: []
   #    - name: LOADBALANCERPROVIDERHAPROXY_EVENTS_SUBSCRIBER_NATS_CREDSFILE
   #      value: "/creds"


### PR DESCRIPTION
Adds ability to the helm chart for specifying additional `envFrom` values, which will allow for pulling in env variables from secrets containing things like OIDC Client secrets.