### PR TITLE
Release IP address on LB delete

### DIFF
--- a/chart/loadbalancer-provider-haproxy/templates/deployment.yaml
+++ b/chart/loadbalancer-provider-haproxy/templates/deployment.yaml
@@ -61,8 +61,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - process
-          {{- range .Values.provider.events.topics }}
-            - --event-topics={{ . }}
+          {{- range .Values.provider.events.changeTopics }}
+            - --change-topics={{ . }}
           {{- end }}
           ports:
             - name: hc

--- a/chart/loadbalancer-provider-haproxy/values.yaml
+++ b/chart/loadbalancer-provider-haproxy/values.yaml
@@ -44,7 +44,7 @@ provider:
       secretName: ""
       credsPath: "/creds"
     topicPrefix: "com.infratographer"
-    topics:
+    changeTopics:
       - "changes.*.lb"
       - "events.create.port"
 

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -43,6 +43,9 @@ func init() {
 	processCmd.PersistentFlags().String("api-endpoint", "http://localhost:4000", "endpoint for configured supergraph.")
 	viperx.MustBindFlag(viper.GetViper(), "api-endpoint", processCmd.PersistentFlags().Lookup("api-endpoint"))
 
+	processCmd.PersistentFlags().String("ipam-endpoint", "http://localhost:4000", "endpoint for ipam api.")
+	viperx.MustBindFlag(viper.GetViper(), "ipam-endpoint", processCmd.PersistentFlags().Lookup("ipam-endpoint"))
+
 	processCmd.PersistentFlags().StringSlice("event-locations", nil, "location id(s) to filter events for")
 	viperx.MustBindFlag(viper.GetViper(), "event-locations", processCmd.PersistentFlags().Lookup("event-locations"))
 
@@ -88,12 +91,12 @@ func process(ctx context.Context, logger *zap.SugaredLogger) error {
 		server.APIClient = lbapi.NewClient((viper.GetString("api-endpoint")),
 			lbapi.WithHTTPClient(oauthHTTPClient),
 		)
-		server.IPAMClient = ipamclient.NewClient((viper.GetString("api-endpoint")),
+		server.IPAMClient = ipamclient.NewClient((viper.GetString("ipam-endpoint")),
 			ipamclient.WithHTTPClient(oauthHTTPClient),
 		)
 	} else {
 		server.APIClient = lbapi.NewClient((viper.GetString("api-endpoint")))
-		server.IPAMClient = ipamclient.NewClient((viper.GetString("api-endpoint")))
+		server.IPAMClient = ipamclient.NewClient((viper.GetString("ipam-endpoint")))
 	}
 
 	pub, err := events.NewPublisher(config.AppConfig.Events.Publisher)

--- a/cmd/process.go
+++ b/cmd/process.go
@@ -40,20 +40,14 @@ func init() {
 	// only available as a CLI arg because it shouldn't be something that could accidentially end up in a config file or env var
 	processCmd.Flags().BoolVar(&processDevMode, "dev", false, "dev mode: disables all auth checks, pretty logging, etc.")
 
-	processCmd.PersistentFlags().String("api-endpoint", "http://localhost:7608", "endpoint for load balancer API. defaults to supergraph-endpoint if set")
+	processCmd.PersistentFlags().String("api-endpoint", "http://localhost:4000", "endpoint for configured supergraph.")
 	viperx.MustBindFlag(viper.GetViper(), "api-endpoint", processCmd.PersistentFlags().Lookup("api-endpoint"))
-
-	processCmd.PersistentFlags().String("ipam-endpoint", "http://localhost:7608", "endpoint for IPAM API. defaults to supergraph-endpoint if set")
-	viperx.MustBindFlag(viper.GetViper(), "ipam-endpoint", processCmd.PersistentFlags().Lookup("ipam-endpoint"))
-
-	processCmd.PersistentFlags().String("supergraph-endpoint", "", "endpoint for load balancer API")
-	viperx.MustBindFlag(viper.GetViper(), "supergraph-endpoint", processCmd.PersistentFlags().Lookup("supergraph-endpoint"))
 
 	processCmd.PersistentFlags().StringSlice("event-locations", nil, "location id(s) to filter events for")
 	viperx.MustBindFlag(viper.GetViper(), "event-locations", processCmd.PersistentFlags().Lookup("event-locations"))
 
-	processCmd.PersistentFlags().StringSlice("event-topics", nil, "event topics to subscribe to")
-	viperx.MustBindFlag(viper.GetViper(), "event-topics", processCmd.PersistentFlags().Lookup("event-topics"))
+	processCmd.PersistentFlags().StringSlice("change-topics", nil, "change topics to subscribe to")
+	viperx.MustBindFlag(viper.GetViper(), "change-topics", processCmd.PersistentFlags().Lookup("change-topics"))
 
 	processCmd.PersistentFlags().String("ipblock", "", "ip block id to use for requesting load balancer IPs")
 	viperx.MustBindFlag(viper.GetViper(), "ipblock", processCmd.PersistentFlags().Lookup("ipblock"))
@@ -84,22 +78,22 @@ func process(ctx context.Context, logger *zap.SugaredLogger) error {
 		Locations:        viper.GetStringSlice("event-locations"),
 		Logger:           logger,
 		SubscriberConfig: config.AppConfig.Events.Subscriber,
-		Topics:           viper.GetStringSlice("event-topics"),
+		ChangeTopics:     viper.GetStringSlice("change-topics"),
 		IPBlock:          viper.GetString("ipblock"),
 	}
 
 	// init lbapi client and ipam client
 	if config.AppConfig.OIDC.ClientID != "" {
 		oauthHTTPClient := oauth2x.NewClient(ctx, oauth2x.NewClientCredentialsTokenSrc(ctx, config.AppConfig.OIDC))
-		server.APIClient = lbapi.NewClient(determineEndpoint(viper.GetString("api-endpoint"), viper.GetString("supergraph-endpoint")),
+		server.APIClient = lbapi.NewClient((viper.GetString("api-endpoint")),
 			lbapi.WithHTTPClient(oauthHTTPClient),
 		)
-		server.IPAMClient = ipamclient.NewClient(determineEndpoint(viper.GetString("api-endpoint"), viper.GetString("supergraph-endpoint")),
+		server.IPAMClient = ipamclient.NewClient((viper.GetString("api-endpoint")),
 			ipamclient.WithHTTPClient(oauthHTTPClient),
 		)
 	} else {
-		server.APIClient = lbapi.NewClient(determineEndpoint(viper.GetString("api-endpoint"), viper.GetString("supergraph-endpoint")))
-		server.IPAMClient = ipamclient.NewClient(determineEndpoint(viper.GetString("ipam-endpoint"), viper.GetString("supergraph-endpoint")))
+		server.APIClient = lbapi.NewClient((viper.GetString("api-endpoint")))
+		server.IPAMClient = ipamclient.NewClient((viper.GetString("api-endpoint")))
 	}
 
 	pub, err := events.NewPublisher(config.AppConfig.Events.Publisher)
@@ -123,12 +117,4 @@ func process(ctx context.Context, logger *zap.SugaredLogger) error {
 	logger.Infof("exiting. Performing necessary cleanup", recvSig)
 
 	return nil
-}
-
-func determineEndpoint(endpoint string, supergraph string) string {
-	if supergraph != "" {
-		return supergraph
-	}
-
-	return endpoint
 }

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module go.infratographer.com/loadbalancer-provider-haproxy
 
 go 1.20
 
+replace go.infratographer.com/ipam-api => github.com/rizzza/ipam-api v0.0.0-20230630002828-9949ef66f0f9
+
 require (
 	github.com/ThreeDotsLabs/watermill v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -9,10 +11,10 @@ require (
 	github.com/spf13/viper v1.16.0
 	github.com/stretchr/testify v1.8.4
 	go.infratographer.com/ipam-api v0.0.3-0.20230627135853-8acda8f15bbe
-	go.infratographer.com/loadbalancer-manager-haproxy v0.0.2-0.20230629042532-5524391bd0b6
+	go.infratographer.com/loadbalancer-manager-haproxy v0.0.2
 	go.infratographer.com/x v0.3.2
 	go.uber.org/zap v1.24.0
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df
 )
 
 require (
@@ -44,15 +46,15 @@ require (
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.18 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/minio/highwayhash v1.0.2 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/nats-io/jwt/v2 v2.4.1 // indirect
-	github.com/nats-io/nats-server/v2 v2.9.17 // indirect
-	github.com/nats-io/nats.go v1.26.0 // indirect
+	github.com/nats-io/nats-server/v2 v2.9.19 // indirect
+	github.com/nats-io/nats.go v1.27.1 // indirect
 	github.com/nats-io/nkeys v0.4.4 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,7 +51,7 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/brianvoe/gofakeit/v6 v6.21.0 h1:tNkm9yxEbpuPK8Bx39tT4sSc5i9SUGiciLdNix+VDQY=
+github.com/brianvoe/gofakeit/v6 v6.22.0 h1:BzOsDot1o3cufTfOk+fWKE9nFYojyDV+XHdCWL2+uyE=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
 github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -214,8 +214,8 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
-github.com/mattn/go-isatty v0.0.18 h1:DOKFKCQ7FNG2L1rbrmstDN4QVRdS89Nkh85u68Uwp98=
-github.com/mattn/go-isatty v0.0.18/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
+github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
@@ -231,10 +231,10 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/nats-io/jwt/v2 v2.4.1 h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
 github.com/nats-io/jwt/v2 v2.4.1/go.mod h1:24BeQtRwxRV8ruvC4CojXlx/WQ/VjuwlYiH+vu/+ibI=
-github.com/nats-io/nats-server/v2 v2.9.17 h1:gFpUQ3hqIDJrnqog+Bl5vaXg+RhhYEZIElasEuRn2tw=
-github.com/nats-io/nats-server/v2 v2.9.17/go.mod h1:eQysm3xDZmIjfkjr7DuD9DjRFpnxQc2vKVxtEg0Dp6s=
-github.com/nats-io/nats.go v1.26.0 h1:fWJTYPnZ8DzxIaqIHOAMfColuznchnd5Ab5dbJpgPIE=
-github.com/nats-io/nats.go v1.26.0/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
+github.com/nats-io/nats-server/v2 v2.9.19 h1:OF9jSKZGo425C/FcVVIvNgpd36CUe7aVTTXEZRJk6kA=
+github.com/nats-io/nats-server/v2 v2.9.19/go.mod h1:aTb/xtLCGKhfTFLxP591CMWfkdgBmcUUSkiSOe5A3gw=
+github.com/nats-io/nats.go v1.27.1 h1:OuYnal9aKVSnOzLQIzf7554OXMCG7KbaTkCSBHRcSoo=
+github.com/nats-io/nats.go v1.27.1/go.mod h1:XpbWUlOElGwTYbMR7imivs7jJj9GtK7ypv321Wp6pjc=
 github.com/nats-io/nkeys v0.4.4 h1:xvBJ8d69TznjcQl9t6//Q5xXuVhyYiSos6RPtvQNTwA=
 github.com/nats-io/nkeys v0.4.4/go.mod h1:XUkxdLPTufzlihbamfzQ7mw/VGx6ObUs+0bN5sNvt64=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
@@ -257,6 +257,8 @@ github.com/prometheus/common v0.40.0 h1:Afz7EVRqGg2Mqqf4JuF9vdvp1pi220m55Pi9T2Jn
 github.com/prometheus/common v0.40.0/go.mod h1:L65ZJPSmfn/UBWLQIHV7dBrKFidB/wPlF1y5TlSt9OE=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
+github.com/rizzza/ipam-api v0.0.0-20230630002828-9949ef66f0f9 h1:cz1L5kMGZzZzqL4at+vyOVwNEjZh+l6VNdsHX4uUvno=
+github.com/rizzza/ipam-api v0.0.0-20230630002828-9949ef66f0f9/go.mod h1:thDypoVMMbTmR1cpOkT2yMNylC/QB233Slm7XTwxc4g=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
@@ -302,10 +304,8 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-go.infratographer.com/ipam-api v0.0.3-0.20230627135853-8acda8f15bbe h1:FEVVwb8uQyhHnS/JPLiESecdtbePQ44hss7GiG0xI4o=
-go.infratographer.com/ipam-api v0.0.3-0.20230627135853-8acda8f15bbe/go.mod h1:AYzfwMo3pcgtc/9FbkJIJ0XYsGFCYoKOmeriwEp3pzk=
-go.infratographer.com/loadbalancer-manager-haproxy v0.0.2-0.20230629042532-5524391bd0b6 h1:xUXYHpIUBapFCRfr4TTk7DuycJwPA25Y2emaoEycum0=
-go.infratographer.com/loadbalancer-manager-haproxy v0.0.2-0.20230629042532-5524391bd0b6/go.mod h1:mrwcbc0ljw0up+sX+umoa1FydiqSeMiynlR6QIO9dqU=
+go.infratographer.com/loadbalancer-manager-haproxy v0.0.2 h1:4d7u5dDfg3NQU2Ccq7ToGZEbRvTujjarRAyqWT2X0RE=
+go.infratographer.com/loadbalancer-manager-haproxy v0.0.2/go.mod h1:mrwcbc0ljw0up+sX+umoa1FydiqSeMiynlR6QIO9dqU=
 go.infratographer.com/x v0.3.2 h1:AxHY77AGhWcRNcO7ENP/4Cj0xg6KGKpxFn/yZn+rPOs=
 go.infratographer.com/x v0.3.2/go.mod h1:GvOhGwi/1Dp5qAQSudHUdLfFmiXzzc27KBfkH0nxnEQ=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
@@ -366,8 +366,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df h1:UA2aFVmmsIlefxMk29Dp2juaUSth8Pyn3Tq5Y5mJGME=
+golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/ipam/handlers.go
+++ b/internal/ipam/handlers.go
@@ -12,7 +12,7 @@ import (
 
 // RequestAddress will request an address for the specified loadbalancer
 func RequestAddress(ctx context.Context, c *ipamclient.Client, logger *zap.SugaredLogger, blockID string, lbID string, lbOwner string) (string, error) {
-	logger.Debugw("requesting address", "loadbalancer_id", lbID)
+	logger.Infow("requesting address", "loadbalancer_id", lbID)
 
 	ip, err := c.CreateIPAddressFromBlock(ctx, blockID, lbID, lbOwner, false)
 	if err != nil {
@@ -20,12 +20,32 @@ func RequestAddress(ctx context.Context, c *ipamclient.Client, logger *zap.Sugar
 		return "", err
 	}
 
+	logger.Infow("address requested", "loadbalancer_id", lbID, "ip_address", ip.IPAddress.IPAddress.IP)
+
 	return ip.IPAddress.IPAddress.IP, nil
 }
 
 // ReleaseAddress will release an address from the specified loadbalancer
 func ReleaseAddress(ctx context.Context, c *ipamclient.Client, logger *zap.SugaredLogger, lbID string) error {
-	// TODO: actually release address
-	logger.Debugw("releasing address", "loadbalancer_id", lbID)
+	logger.Infow("releasing address", "loadbalancer_id", lbID)
+
+	// TODO: this is a hack as we don't have a way to get the IP address from the loadbalancer as
+	// it has already been deleted. We're using an entities query directly against IPAM to get what
+	// we need. Ideally we could query the supergraph for this, but need to look into softdeletes so
+	// that the LB data is still available after a delete.
+	addr, err := c.GetIPAddresses(ctx, lbID)
+	if err != nil {
+		logger.Debugw("unable to get ip address for loadbalancer", "error", err, "load balancer", lbID)
+	}
+
+	for _, ip := range addr.Entities[0].IPAddressableFragment.IPAddresses {
+		if _, err := c.DeleteIPAddress(ctx, ip.ID); err != nil {
+			logger.Debugw("unable to release ip address from loadbalancer", "error", err, "load balancer", lbID, "IPAddressID", ip.ID, "IPAddress", ip.IP)
+			return err
+		}
+
+		logger.Infow("released ip address from loadbalancer", "error", err, "load balancer", lbID, "IPAddressID", ip.ID, "IPAddress", ip.IP)
+	}
+
 	return nil
 }

--- a/internal/server/changes.go
+++ b/internal/server/changes.go
@@ -33,5 +33,16 @@ func (s *Server) processLoadBalancerChangeDelete(lb *loadbalancer.LoadBalancer) 
 		return err
 	}
 
+	msg := events.EventMessage{
+		EventType: "ip-address.unassigned",
+		SubjectID: lb.LoadBalancerID,
+		Timestamp: time.Now().UTC(),
+	}
+
+	if err := s.Publisher.PublishEvent(s.Context, "load-balancer", msg); err != nil {
+		s.Logger.Debugw("failed to publish event", "error", err, "loadbalancer", lb.LoadBalancerID, "block", s.IPBlock)
+		return err
+	}
+
 	return nil
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -48,6 +48,7 @@ func (s *Server) ProcessChange(messages <-chan *message.Message) {
 					}
 				case m.EventType == string(events.DeleteChangeType) && lb.LbType == loadbalancer.TypeLB:
 					s.Logger.Debugw("releasing address from loadbalancer", "loadbalancer", lb.LoadBalancerID.String())
+
 					if err := s.processLoadBalancerChangeDelete(lb); err != nil {
 						s.Logger.Errorw("handler unable to release address from loadbalancer", "error", err, "loadbalancer", lb.LoadBalancerID.String())
 						msg.Nack()

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -48,7 +48,6 @@ func (s *Server) ProcessChange(messages <-chan *message.Message) {
 					}
 				case m.EventType == string(events.DeleteChangeType) && lb.LbType == loadbalancer.TypeLB:
 					s.Logger.Debugw("releasing address from loadbalancer", "loadbalancer", lb.LoadBalancerID.String())
-
 					if err := s.processLoadBalancerChangeDelete(lb); err != nil {
 						s.Logger.Errorw("handler unable to release address from loadbalancer", "error", err, "loadbalancer", lb.LoadBalancerID.String())
 						msg.Nack()

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -60,7 +60,7 @@ func TestProcessChange(t *testing.T) { //nolint:govet
 		Locations:        []string{"abcd1234"},
 		Logger:           zap.NewNop().Sugar(),
 		SubscriberConfig: nats.SubscriberConfig,
-		Topics:           []string{"*.load-balancer"},
+		ChangeTopics:     []string{"*.load-balancer"},
 	}
 
 	// TODO: check that namespace does not exist

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,7 +24,7 @@ type Server struct {
 	Logger           *zap.SugaredLogger
 	Publisher        *events.Publisher
 	SubscriberConfig events.SubscriberConfig
-	Topics           []string
+	ChangeTopics     []string
 
 	ChangeChannels []<-chan *message.Message
 }
@@ -54,7 +54,7 @@ func (s *Server) Run(ctx context.Context) error {
 func (s *Server) ConfigureSubscribers() error {
 	var ch []<-chan *message.Message
 
-	for _, topic := range s.Topics {
+	for _, topic := range s.ChangeTopics {
 		s.Logger.Debugw("subscribing to topic", "topic", topic)
 
 		csub, err := events.NewSubscriber(s.SubscriberConfig)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -30,7 +30,7 @@ func TestRun(t *testing.T) {
 		Locations:        []string{"abcd1234"},
 		Logger:           zap.NewNop().Sugar(),
 		SubscriberConfig: nats.SubscriberConfig,
-		Topics:           []string{"*.load-balancer-run"},
+		ChangeTopics:     []string{"*.load-balancer-run"},
 	}
 
 	err := srv.Run(srv.Context)

--- a/internal/testutils/mock/mock.go
+++ b/internal/testutils/mock/mock.go
@@ -67,12 +67,20 @@ func DummyIPAMAPI(id string) *httptest.Server {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		// TODO: Fill in IPAM mock
-		// out := fmt.Sprintf(`{
-		// 	"data": {},
-		// 	"errors": []
-		// }`, id)
-		out := ""
+		out := (`{
+			"data": {
+				"_entities": [
+				  {
+					"IPAddresses": [
+					  {
+						"ip": "192.168.10.5"
+					  },
+					]
+				  }
+				]
+			  }
+			}
+		}`)
 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(out))

--- a/internal/testutils/mock/mock.go
+++ b/internal/testutils/mock/mock.go
@@ -67,20 +67,37 @@ func DummyIPAMAPI(id string) *httptest.Server {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		out := (`{
+		// out := (`{
+		// 	"data": {
+		// 		"_entities": [
+		// 		  {
+		// 			"IPAddresses": [
+		// 			  {
+		// 				"id": "ipaddr-2fiP_C_gnAORx_oDbNJAf",
+		// 				"ip": "192.168.10.5"
+		// 			  },
+		// 			]
+		// 		  }
+		// 		]
+		// 	  }
+		// 	}
+		// }`)
+
+		out := fmt.Sprintf(`{
 			"data": {
 				"_entities": [
 				  {
 					"IPAddresses": [
 					  {
+						"id": "%s",
 						"ip": "192.168.10.5"
-					  },
+					  }
 					]
 				  }
 				]
-			  }
-			}
-		}`)
+			},
+			"errors": []
+		}`, id)
 
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(out))


### PR DESCRIPTION
This adds a (current hacky) fix to the provider that will allow for releasing an IP address when a load balancer has been deleted. It does this by querying directly against the ipam-api (as _entities isn't available in the supergraph). It then returns IP addresses associated with a particular load balancer ID and proceeds to run a `DeleteIPAddress` against the IPAM API.